### PR TITLE
PLAT-48662: switch to use node net instead of native nc by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,9 @@ function nodeNetCatSrc(port, input) {
   );
 }
 
-const FUNCTION_PRIORITY = [nativeNC, nodeNC];
+// Use nodeNC to avoid native nc error (spawnSync error observed with mac os 11.2.3)
+// https://nodejs.org/api/net.html#netconnect
+const FUNCTION_PRIORITY = [nodeNC, nativeNC];
 const FLAGS = isElectron() ? ['--ms-enable-electron-run-as-node'] : [];
 
 let started = false;


### PR DESCRIPTION
more description of the issue we observed can be found here: https://c3energy.atlassian.net/browse/PLAT-48662